### PR TITLE
Add weather pages for destinations

### DIFF
--- a/crete.html
+++ b/crete.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Crete Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #101116;
+      --card: #1b1c22;
+      --card-hover: #23242b;
+      --accent: #38bdf8;
+      --accent2: #0ea5e9;
+      --text: #fff;
+      --subtext: #cbd5e1;
+    }
+    body {
+      margin: 0;
+      background: linear-gradient(180deg, #191b21 0%, #101116 80%);
+      min-height: 100vh;
+      font-family: 'Inter', sans-serif;
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0 12px;
+    }
+    header {
+      text-align: center;
+      margin-top: 50px;
+      margin-bottom: 30px;
+    }
+    h1 {
+      font-size: 2.4rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .forecast {
+      width: 100%;
+      max-width: 600px;
+      border-collapse: collapse;
+      margin-bottom: 40px;
+    }
+    .forecast th,
+    .forecast td {
+      border: 1px solid #2a2b38;
+      padding: 8px 12px;
+      text-align: center;
+    }
+    .forecast th {
+      background: #1b1c22;
+    }
+    .signup-section {
+      margin: 0 auto 60px auto;
+      background: linear-gradient(120deg, #23242b 50%, #192f4c 100%);
+      border-radius: 1.4rem;
+      box-shadow: 0 4px 32px #0004;
+      padding: 38px 26px 32px 26px;
+      max-width: 420px;
+      width: 98%;
+      border: 1.5px solid #212238;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .signup-section h3 {
+      font-size: 1.3rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .signup-section p {
+      color: var(--subtext);
+      font-size: 1rem;
+      margin-bottom: 18px;
+      text-align: center;
+      line-height: 1.6;
+    }
+    .signup-form {
+      width: 100%;
+      display: flex;
+      gap: 8px;
+      flex-direction: column;
+      align-items: stretch;
+    }
+    @media (min-width: 520px) {
+      .signup-form { flex-direction: row; }
+    }
+    .signup-form input[type=email] {
+      background: #16181e;
+      border: 1.5px solid #2a2b38;
+      border-radius: 999px;
+      color: var(--text);
+      padding: 12px 22px;
+      font-size: 1rem;
+      flex: 1 1 auto;
+      outline: none;
+      transition: border 0.2s;
+    }
+    .signup-form input[type=email]:focus {
+      border: 1.5px solid var(--accent);
+    }
+    .signup-form button {
+      background: linear-gradient(90deg, var(--accent2) 40%, var(--accent) 100%);
+      border: none;
+      border-radius: 999px;
+      color: #fff;
+      padding: 12px 30px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 2px 12px #0ea5e955;
+      transition: transform 0.14s, box-shadow 0.16s;
+    }
+    .signup-form button:hover {
+      transform: scale(1.06);
+      box-shadow: 0 4px 18px #38bdf844;
+    }
+    a.home-link {
+      color: var(--accent);
+      text-decoration: none;
+      margin-bottom: 30px;
+    }
+    footer {
+      margin: 40px 0 20px 0;
+      color: #7b8291;
+      font-size: 0.93rem;
+      text-align: center;
+      opacity: 0.7;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Crete Weather</h1>
+  </header>
+  <table class="forecast">
+    <tr><th>Day</th><th>Condition</th><th>High / Low</th></tr>
+    <tr><td>Monday</td><td>Sunny</td><td>27°C / 19°C</td></tr>
+    <tr><td>Tuesday</td><td>Partly Cloudy</td><td>25°C / 18°C</td></tr>
+    <tr><td>Wednesday</td><td>Sunny</td><td>28°C / 19°C</td></tr>
+    <tr><td>Thursday</td><td>Sunny</td><td>28°C / 19°C</td></tr>
+    <tr><td>Friday</td><td>Cloudy</td><td>23°C / 17°C</td></tr>
+    <tr><td>Saturday</td><td>Sunny</td><td>25°C / 18°C</td></tr>
+    <tr><td>Sunday</td><td>Sunny</td><td>27°C / 19°C</td></tr>
+  </table>
+  <a href="index.html" class="home-link">&larr; Back to Home</a>
+  <section class="signup-section">
+    <h3>Sign up for more info</h3>
+    <p>Stay informed about weather updates for Crete.</p>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thank you for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <footer>
+    © 2025 Holiday Weather. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/dubrovnik.html
+++ b/dubrovnik.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dubrovnik Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #101116;
+      --card: #1b1c22;
+      --card-hover: #23242b;
+      --accent: #38bdf8;
+      --accent2: #0ea5e9;
+      --text: #fff;
+      --subtext: #cbd5e1;
+    }
+    body {
+      margin: 0;
+      background: linear-gradient(180deg, #191b21 0%, #101116 80%);
+      min-height: 100vh;
+      font-family: 'Inter', sans-serif;
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0 12px;
+    }
+    header {
+      text-align: center;
+      margin-top: 50px;
+      margin-bottom: 30px;
+    }
+    h1 {
+      font-size: 2.4rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .forecast {
+      width: 100%;
+      max-width: 600px;
+      border-collapse: collapse;
+      margin-bottom: 40px;
+    }
+    .forecast th,
+    .forecast td {
+      border: 1px solid #2a2b38;
+      padding: 8px 12px;
+      text-align: center;
+    }
+    .forecast th {
+      background: #1b1c22;
+    }
+    .signup-section {
+      margin: 0 auto 60px auto;
+      background: linear-gradient(120deg, #23242b 50%, #192f4c 100%);
+      border-radius: 1.4rem;
+      box-shadow: 0 4px 32px #0004;
+      padding: 38px 26px 32px 26px;
+      max-width: 420px;
+      width: 98%;
+      border: 1.5px solid #212238;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .signup-section h3 {
+      font-size: 1.3rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .signup-section p {
+      color: var(--subtext);
+      font-size: 1rem;
+      margin-bottom: 18px;
+      text-align: center;
+      line-height: 1.6;
+    }
+    .signup-form {
+      width: 100%;
+      display: flex;
+      gap: 8px;
+      flex-direction: column;
+      align-items: stretch;
+    }
+    @media (min-width: 520px) {
+      .signup-form { flex-direction: row; }
+    }
+    .signup-form input[type=email] {
+      background: #16181e;
+      border: 1.5px solid #2a2b38;
+      border-radius: 999px;
+      color: var(--text);
+      padding: 12px 22px;
+      font-size: 1rem;
+      flex: 1 1 auto;
+      outline: none;
+      transition: border 0.2s;
+    }
+    .signup-form input[type=email]:focus {
+      border: 1.5px solid var(--accent);
+    }
+    .signup-form button {
+      background: linear-gradient(90deg, var(--accent2) 40%, var(--accent) 100%);
+      border: none;
+      border-radius: 999px;
+      color: #fff;
+      padding: 12px 30px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 2px 12px #0ea5e955;
+      transition: transform 0.14s, box-shadow 0.16s;
+    }
+    .signup-form button:hover {
+      transform: scale(1.06);
+      box-shadow: 0 4px 18px #38bdf844;
+    }
+    a.home-link {
+      color: var(--accent);
+      text-decoration: none;
+      margin-bottom: 30px;
+    }
+    footer {
+      margin: 40px 0 20px 0;
+      color: #7b8291;
+      font-size: 0.93rem;
+      text-align: center;
+      opacity: 0.7;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Dubrovnik Weather</h1>
+  </header>
+  <table class="forecast">
+    <tr><th>Day</th><th>Condition</th><th>High / Low</th></tr>
+    <tr><td>Monday</td><td>Sunny</td><td>23°C / 15°C</td></tr>
+    <tr><td>Tuesday</td><td>Partly Cloudy</td><td>22°C / 14°C</td></tr>
+    <tr><td>Wednesday</td><td>Sunny</td><td>24°C / 15°C</td></tr>
+    <tr><td>Thursday</td><td>Sunny</td><td>25°C / 16°C</td></tr>
+    <tr><td>Friday</td><td>Cloudy</td><td>23°C / 17°C</td></tr>
+    <tr><td>Saturday</td><td>Sunny</td><td>23°C / 15°C</td></tr>
+    <tr><td>Sunday</td><td>Sunny</td><td>23°C / 15°C</td></tr>
+  </table>
+  <a href="index.html" class="home-link">&larr; Back to Home</a>
+  <section class="signup-section">
+    <h3>Sign up for more info</h3>
+    <p>Stay informed about weather updates for Dubrovnik.</p>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thank you for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <footer>
+    © 2025 Holiday Weather. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -52,10 +52,10 @@
       padding: 0 12px;
     }
     @media (min-width: 700px) {
-      .locations-grid { grid-template-columns: repeat(2, 1fr);}
+      .locations-grid { grid-template-columns: repeat(2, 1fr); }
     }
     @media (min-width: 1050px) {
-      .locations-grid { grid-template-columns: repeat(4, 1fr);}
+      .locations-grid { grid-template-columns: repeat(3, 1fr); }
     }
     .location-card {
       background: var(--card);
@@ -134,9 +134,7 @@
       align-items: stretch;
     }
     @media (min-width: 520px) {
-      .signup-form {
-        flex-direction: row;
-      }
+      .signup-form { flex-direction: row; }
     }
     .signup-form input[type=email] {
       background: #16181e;
@@ -180,34 +178,48 @@
 <body>
   <header>
     <h1>Holiday Weather</h1>
-    <p>Track the weather for your favourite destinations - never get caught in the rain again. Sign up for the latest weather alerts.</p>
+    <p>Select a destination to see next week's forecast.</p>
   </header>
   <div class="locations-grid">
-    <a class="location-card" href="#malaga">
+    <a class="location-card" href="malaga.html">
       <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80');"></div>
       <div class="card-content">
         <h2>Malaga</h2>
         <span>See latest weather</span>
       </div>
     </a>
-    <a class="location-card" href="#tenerife">
+    <a class="location-card" href="tenerife.html">
       <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1464983953574-0892a716854b?auto=format&fit=crop&w=800&q=80');"></div>
       <div class="card-content">
         <h2>Tenerife</h2>
         <span>See latest weather</span>
       </div>
     </a>
-    <a class="location-card" href="#crete">
+    <a class="location-card" href="crete.html">
       <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=800&q=80');"></div>
       <div class="card-content">
         <h2>Crete</h2>
         <span>See latest weather</span>
       </div>
     </a>
-    <a class="location-card" href="#dubrovnik">
+    <a class="location-card" href="dubrovnik.html">
       <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1467269204594-9661b134dd2b?auto=format&fit=crop&w=800&q=80');"></div>
       <div class="card-content">
         <h2>Dubrovnik</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="paris.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1522098543979-ffc7f79d9515?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Paris</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="newyork.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1549924231-f129b911e442?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>New York</h2>
         <span>See latest weather</span>
       </div>
     </a>

--- a/malaga.html
+++ b/malaga.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Malaga Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #101116;
+      --card: #1b1c22;
+      --card-hover: #23242b;
+      --accent: #38bdf8;
+      --accent2: #0ea5e9;
+      --text: #fff;
+      --subtext: #cbd5e1;
+    }
+    body {
+      margin: 0;
+      background: linear-gradient(180deg, #191b21 0%, #101116 80%);
+      min-height: 100vh;
+      font-family: 'Inter', sans-serif;
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0 12px;
+    }
+    header {
+      text-align: center;
+      margin-top: 50px;
+      margin-bottom: 30px;
+    }
+    h1 {
+      font-size: 2.4rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .forecast {
+      width: 100%;
+      max-width: 600px;
+      border-collapse: collapse;
+      margin-bottom: 40px;
+    }
+    .forecast th,
+    .forecast td {
+      border: 1px solid #2a2b38;
+      padding: 8px 12px;
+      text-align: center;
+    }
+    .forecast th {
+      background: #1b1c22;
+    }
+    .signup-section {
+      margin: 0 auto 60px auto;
+      background: linear-gradient(120deg, #23242b 50%, #192f4c 100%);
+      border-radius: 1.4rem;
+      box-shadow: 0 4px 32px #0004;
+      padding: 38px 26px 32px 26px;
+      max-width: 420px;
+      width: 98%;
+      border: 1.5px solid #212238;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .signup-section h3 {
+      font-size: 1.3rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .signup-section p {
+      color: var(--subtext);
+      font-size: 1rem;
+      margin-bottom: 18px;
+      text-align: center;
+      line-height: 1.6;
+    }
+    .signup-form {
+      width: 100%;
+      display: flex;
+      gap: 8px;
+      flex-direction: column;
+      align-items: stretch;
+    }
+    @media (min-width: 520px) {
+      .signup-form { flex-direction: row; }
+    }
+    .signup-form input[type=email] {
+      background: #16181e;
+      border: 1.5px solid #2a2b38;
+      border-radius: 999px;
+      color: var(--text);
+      padding: 12px 22px;
+      font-size: 1rem;
+      flex: 1 1 auto;
+      outline: none;
+      transition: border 0.2s;
+    }
+    .signup-form input[type=email]:focus {
+      border: 1.5px solid var(--accent);
+    }
+    .signup-form button {
+      background: linear-gradient(90deg, var(--accent2) 40%, var(--accent) 100%);
+      border: none;
+      border-radius: 999px;
+      color: #fff;
+      padding: 12px 30px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 2px 12px #0ea5e955;
+      transition: transform 0.14s, box-shadow 0.16s;
+    }
+    .signup-form button:hover {
+      transform: scale(1.06);
+      box-shadow: 0 4px 18px #38bdf844;
+    }
+    a.home-link {
+      color: var(--accent);
+      text-decoration: none;
+      margin-bottom: 30px;
+    }
+    footer {
+      margin: 40px 0 20px 0;
+      color: #7b8291;
+      font-size: 0.93rem;
+      text-align: center;
+      opacity: 0.7;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Malaga Weather</h1>
+  </header>
+  <table class="forecast">
+    <tr><th>Day</th><th>Condition</th><th>High / Low</th></tr>
+    <tr><td>Monday</td><td>Sunny</td><td>26°C / 18°C</td></tr>
+    <tr><td>Tuesday</td><td>Partly Cloudy</td><td>24°C / 17°C</td></tr>
+    <tr><td>Wednesday</td><td>Sunny</td><td>27°C / 18°C</td></tr>
+    <tr><td>Thursday</td><td>Sunny</td><td>28°C / 19°C</td></tr>
+    <tr><td>Friday</td><td>Cloudy</td><td>23°C / 17°C</td></tr>
+    <tr><td>Saturday</td><td>Sunny</td><td>25°C / 18°C</td></tr>
+    <tr><td>Sunday</td><td>Sunny</td><td>26°C / 18°C</td></tr>
+  </table>
+  <a href="index.html" class="home-link">&larr; Back to Home</a>
+  <section class="signup-section">
+    <h3>Sign up for more info</h3>
+    <p>Stay informed about weather updates for Malaga.</p>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thank you for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <footer>
+    © 2025 Holiday Weather. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/newyork.html
+++ b/newyork.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>New York Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #101116;
+      --card: #1b1c22;
+      --card-hover: #23242b;
+      --accent: #38bdf8;
+      --accent2: #0ea5e9;
+      --text: #fff;
+      --subtext: #cbd5e1;
+    }
+    body {
+      margin: 0;
+      background: linear-gradient(180deg, #191b21 0%, #101116 80%);
+      min-height: 100vh;
+      font-family: 'Inter', sans-serif;
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0 12px;
+    }
+    header {
+      text-align: center;
+      margin-top: 50px;
+      margin-bottom: 30px;
+    }
+    h1 {
+      font-size: 2.4rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .forecast {
+      width: 100%;
+      max-width: 600px;
+      border-collapse: collapse;
+      margin-bottom: 40px;
+    }
+    .forecast th,
+    .forecast td {
+      border: 1px solid #2a2b38;
+      padding: 8px 12px;
+      text-align: center;
+    }
+    .forecast th {
+      background: #1b1c22;
+    }
+    .signup-section {
+      margin: 0 auto 60px auto;
+      background: linear-gradient(120deg, #23242b 50%, #192f4c 100%);
+      border-radius: 1.4rem;
+      box-shadow: 0 4px 32px #0004;
+      padding: 38px 26px 32px 26px;
+      max-width: 420px;
+      width: 98%;
+      border: 1.5px solid #212238;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .signup-section h3 {
+      font-size: 1.3rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .signup-section p {
+      color: var(--subtext);
+      font-size: 1rem;
+      margin-bottom: 18px;
+      text-align: center;
+      line-height: 1.6;
+    }
+    .signup-form {
+      width: 100%;
+      display: flex;
+      gap: 8px;
+      flex-direction: column;
+      align-items: stretch;
+    }
+    @media (min-width: 520px) {
+      .signup-form { flex-direction: row; }
+    }
+    .signup-form input[type=email] {
+      background: #16181e;
+      border: 1.5px solid #2a2b38;
+      border-radius: 999px;
+      color: var(--text);
+      padding: 12px 22px;
+      font-size: 1rem;
+      flex: 1 1 auto;
+      outline: none;
+      transition: border 0.2s;
+    }
+    .signup-form input[type=email]:focus {
+      border: 1.5px solid var(--accent);
+    }
+    .signup-form button {
+      background: linear-gradient(90deg, var(--accent2) 40%, var(--accent) 100%);
+      border: none;
+      border-radius: 999px;
+      color: #fff;
+      padding: 12px 30px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 2px 12px #0ea5e955;
+      transition: transform 0.14s, box-shadow 0.16s;
+    }
+    .signup-form button:hover {
+      transform: scale(1.06);
+      box-shadow: 0 4px 18px #38bdf844;
+    }
+    a.home-link {
+      color: var(--accent);
+      text-decoration: none;
+      margin-bottom: 30px;
+    }
+    footer {
+      margin: 40px 0 20px 0;
+      color: #7b8291;
+      font-size: 0.93rem;
+      text-align: center;
+      opacity: 0.7;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>New York Weather</h1>
+  </header>
+  <table class="forecast">
+    <tr><th>Day</th><th>Condition</th><th>High / Low</th></tr>
+    <tr><td>Monday</td><td>Sunny</td><td>20°C / 13°C</td></tr>
+    <tr><td>Tuesday</td><td>Partly Cloudy</td><td>19°C / 12°C</td></tr>
+    <tr><td>Wednesday</td><td>Sunny</td><td>21°C / 13°C</td></tr>
+    <tr><td>Thursday</td><td>Sunny</td><td>22°C / 14°C</td></tr>
+    <tr><td>Friday</td><td>Cloudy</td><td>23°C / 17°C</td></tr>
+    <tr><td>Saturday</td><td>Sunny</td><td>20°C / 13°C</td></tr>
+    <tr><td>Sunday</td><td>Sunny</td><td>20°C / 13°C</td></tr>
+  </table>
+  <a href="index.html" class="home-link">&larr; Back to Home</a>
+  <section class="signup-section">
+    <h3>Sign up for more info</h3>
+    <p>Stay informed about weather updates for New York.</p>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thank you for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <footer>
+    © 2025 Holiday Weather. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/paris.html
+++ b/paris.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Paris Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #101116;
+      --card: #1b1c22;
+      --card-hover: #23242b;
+      --accent: #38bdf8;
+      --accent2: #0ea5e9;
+      --text: #fff;
+      --subtext: #cbd5e1;
+    }
+    body {
+      margin: 0;
+      background: linear-gradient(180deg, #191b21 0%, #101116 80%);
+      min-height: 100vh;
+      font-family: 'Inter', sans-serif;
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0 12px;
+    }
+    header {
+      text-align: center;
+      margin-top: 50px;
+      margin-bottom: 30px;
+    }
+    h1 {
+      font-size: 2.4rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .forecast {
+      width: 100%;
+      max-width: 600px;
+      border-collapse: collapse;
+      margin-bottom: 40px;
+    }
+    .forecast th,
+    .forecast td {
+      border: 1px solid #2a2b38;
+      padding: 8px 12px;
+      text-align: center;
+    }
+    .forecast th {
+      background: #1b1c22;
+    }
+    .signup-section {
+      margin: 0 auto 60px auto;
+      background: linear-gradient(120deg, #23242b 50%, #192f4c 100%);
+      border-radius: 1.4rem;
+      box-shadow: 0 4px 32px #0004;
+      padding: 38px 26px 32px 26px;
+      max-width: 420px;
+      width: 98%;
+      border: 1.5px solid #212238;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .signup-section h3 {
+      font-size: 1.3rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .signup-section p {
+      color: var(--subtext);
+      font-size: 1rem;
+      margin-bottom: 18px;
+      text-align: center;
+      line-height: 1.6;
+    }
+    .signup-form {
+      width: 100%;
+      display: flex;
+      gap: 8px;
+      flex-direction: column;
+      align-items: stretch;
+    }
+    @media (min-width: 520px) {
+      .signup-form { flex-direction: row; }
+    }
+    .signup-form input[type=email] {
+      background: #16181e;
+      border: 1.5px solid #2a2b38;
+      border-radius: 999px;
+      color: var(--text);
+      padding: 12px 22px;
+      font-size: 1rem;
+      flex: 1 1 auto;
+      outline: none;
+      transition: border 0.2s;
+    }
+    .signup-form input[type=email]:focus {
+      border: 1.5px solid var(--accent);
+    }
+    .signup-form button {
+      background: linear-gradient(90deg, var(--accent2) 40%, var(--accent) 100%);
+      border: none;
+      border-radius: 999px;
+      color: #fff;
+      padding: 12px 30px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 2px 12px #0ea5e955;
+      transition: transform 0.14s, box-shadow 0.16s;
+    }
+    .signup-form button:hover {
+      transform: scale(1.06);
+      box-shadow: 0 4px 18px #38bdf844;
+    }
+    a.home-link {
+      color: var(--accent);
+      text-decoration: none;
+      margin-bottom: 30px;
+    }
+    footer {
+      margin: 40px 0 20px 0;
+      color: #7b8291;
+      font-size: 0.93rem;
+      text-align: center;
+      opacity: 0.7;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Paris Weather</h1>
+  </header>
+  <table class="forecast">
+    <tr><th>Day</th><th>Condition</th><th>High / Low</th></tr>
+    <tr><td>Monday</td><td>Sunny</td><td>22°C / 12°C</td></tr>
+    <tr><td>Tuesday</td><td>Partly Cloudy</td><td>21°C / 11°C</td></tr>
+    <tr><td>Wednesday</td><td>Sunny</td><td>23°C / 12°C</td></tr>
+    <tr><td>Thursday</td><td>Sunny</td><td>24°C / 13°C</td></tr>
+    <tr><td>Friday</td><td>Cloudy</td><td>23°C / 17°C</td></tr>
+    <tr><td>Saturday</td><td>Sunny</td><td>22°C / 12°C</td></tr>
+    <tr><td>Sunday</td><td>Sunny</td><td>22°C / 12°C</td></tr>
+  </table>
+  <a href="index.html" class="home-link">&larr; Back to Home</a>
+  <section class="signup-section">
+    <h3>Sign up for more info</h3>
+    <p>Stay informed about weather updates for Paris.</p>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thank you for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <footer>
+    © 2025 Holiday Weather. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/tenerife.html
+++ b/tenerife.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tenerife Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #101116;
+      --card: #1b1c22;
+      --card-hover: #23242b;
+      --accent: #38bdf8;
+      --accent2: #0ea5e9;
+      --text: #fff;
+      --subtext: #cbd5e1;
+    }
+    body {
+      margin: 0;
+      background: linear-gradient(180deg, #191b21 0%, #101116 80%);
+      min-height: 100vh;
+      font-family: 'Inter', sans-serif;
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0 12px;
+    }
+    header {
+      text-align: center;
+      margin-top: 50px;
+      margin-bottom: 30px;
+    }
+    h1 {
+      font-size: 2.4rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .forecast {
+      width: 100%;
+      max-width: 600px;
+      border-collapse: collapse;
+      margin-bottom: 40px;
+    }
+    .forecast th,
+    .forecast td {
+      border: 1px solid #2a2b38;
+      padding: 8px 12px;
+      text-align: center;
+    }
+    .forecast th {
+      background: #1b1c22;
+    }
+    .signup-section {
+      margin: 0 auto 60px auto;
+      background: linear-gradient(120deg, #23242b 50%, #192f4c 100%);
+      border-radius: 1.4rem;
+      box-shadow: 0 4px 32px #0004;
+      padding: 38px 26px 32px 26px;
+      max-width: 420px;
+      width: 98%;
+      border: 1.5px solid #212238;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .signup-section h3 {
+      font-size: 1.3rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .signup-section p {
+      color: var(--subtext);
+      font-size: 1rem;
+      margin-bottom: 18px;
+      text-align: center;
+      line-height: 1.6;
+    }
+    .signup-form {
+      width: 100%;
+      display: flex;
+      gap: 8px;
+      flex-direction: column;
+      align-items: stretch;
+    }
+    @media (min-width: 520px) {
+      .signup-form { flex-direction: row; }
+    }
+    .signup-form input[type=email] {
+      background: #16181e;
+      border: 1.5px solid #2a2b38;
+      border-radius: 999px;
+      color: var(--text);
+      padding: 12px 22px;
+      font-size: 1rem;
+      flex: 1 1 auto;
+      outline: none;
+      transition: border 0.2s;
+    }
+    .signup-form input[type=email]:focus {
+      border: 1.5px solid var(--accent);
+    }
+    .signup-form button {
+      background: linear-gradient(90deg, var(--accent2) 40%, var(--accent) 100%);
+      border: none;
+      border-radius: 999px;
+      color: #fff;
+      padding: 12px 30px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 2px 12px #0ea5e955;
+      transition: transform 0.14s, box-shadow 0.16s;
+    }
+    .signup-form button:hover {
+      transform: scale(1.06);
+      box-shadow: 0 4px 18px #38bdf844;
+    }
+    a.home-link {
+      color: var(--accent);
+      text-decoration: none;
+      margin-bottom: 30px;
+    }
+    footer {
+      margin: 40px 0 20px 0;
+      color: #7b8291;
+      font-size: 0.93rem;
+      text-align: center;
+      opacity: 0.7;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Tenerife Weather</h1>
+  </header>
+  <table class="forecast">
+    <tr><th>Day</th><th>Condition</th><th>High / Low</th></tr>
+    <tr><td>Monday</td><td>Sunny</td><td>24°C / 17°C</td></tr>
+    <tr><td>Tuesday</td><td>Partly Cloudy</td><td>24°C / 17°C</td></tr>
+    <tr><td>Wednesday</td><td>Sunny</td><td>25°C / 18°C</td></tr>
+    <tr><td>Thursday</td><td>Sunny</td><td>27°C / 19°C</td></tr>
+    <tr><td>Friday</td><td>Cloudy</td><td>23°C / 17°C</td></tr>
+    <tr><td>Saturday</td><td>Sunny</td><td>24°C / 17°C</td></tr>
+    <tr><td>Sunday</td><td>Sunny</td><td>24°C / 17°C</td></tr>
+  </table>
+  <a href="index.html" class="home-link">&larr; Back to Home</a>
+  <section class="signup-section">
+    <h3>Sign up for more info</h3>
+    <p>Stay informed about weather updates for Tenerife.</p>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thank you for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <footer>
+    © 2025 Holiday Weather. All rights reserved.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update index with six clickable destinations
- add destination pages for Malaga, Tenerife, Crete, Dubrovnik, Paris and New York
- each destination page shows a simple 7‑day forecast and signup form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6855390ed0a08332bcb28be711f75481