### PR TITLE
Add vibrant destination pages for top travel spots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Holiday Weather
+
+Simple static site showing weather forecasts for popular holiday destinations. The homepage lists twenty destinations. Clicking a card opens a dedicated page with the 7‑day forecast loaded from the free [Open‑Meteo](https://open-meteo.com/) API. Forecasts show the day of the week and include simple weather icons. Each destination page also features a vibrant hero image and an email signup form.
+
+## Development
+No build step is required. Open `index.html` in a browser or deploy the files to any static host.

--- a/algarve.html
+++ b/algarve.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Algarve Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1484723091739-30a097e8f929?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Algarve Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Algarve updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(37.0194, -7.9304);</script>
+</body>
+</html>
+

--- a/antalya.html
+++ b/antalya.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Antalya Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1588920530457-9b3e8b9001cf?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Antalya Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Antalya updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(36.8969, 30.7133);</script>
+</body>
+</html>
+

--- a/bali.html
+++ b/bali.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bali Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Bali Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Bali updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(-8.3405, 115.0920);</script>
+</body>
+</html>

--- a/barcelona.html
+++ b/barcelona.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Barcelona Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Barcelona Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Barcelona updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(41.3851, 2.1734);</script>
+</body>
+</html>
+

--- a/bodrum.html
+++ b/bodrum.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bodrum Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1532787386201-5c6cddaac82d?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Bodrum Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Bodrum updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(37.0344, 27.4305);</script>
+</body>
+</html>
+

--- a/cancun.html
+++ b/cancun.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Cancun Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1504609813442-a8924e83f76e?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Cancun Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Cancun updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(21.1619, -86.8515);</script>
+</body>
+</html>

--- a/crete.html
+++ b/crete.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Crete Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Crete Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Crete updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(35.2401, 24.8093);</script>
+</body>
+</html>

--- a/dubrovnik.html
+++ b/dubrovnik.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dubrovnik Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1467269204594-9661b134dd2b?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Dubrovnik Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Dubrovnik updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(42.6507, 18.0944);</script>
+</body>
+</html>

--- a/fuerteventura.html
+++ b/fuerteventura.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Fuerteventura Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1560369718-ed280608de1e?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Fuerteventura Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Fuerteventura updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(28.3587, -14.0535);</script>
+</body>
+</html>
+

--- a/grancanaria.html
+++ b/grancanaria.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Gran Canaria Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1601801388668-0e6f52b05971?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Gran Canaria Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Gran Canaria updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(28.1248, -15.43);</script>
+</body>
+</html>
+

--- a/ibiza.html
+++ b/ibiza.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ibiza Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1505728959-c8f323928353?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Ibiza Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Ibiza updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(38.9067, 1.4206);</script>
+</body>
+</html>
+

--- a/index.html
+++ b/index.html
@@ -183,31 +183,143 @@
     <p>Track the weather for your favourite destinations - never get caught in the rain again. Sign up for the latest weather alerts.</p>
   </header>
   <div class="locations-grid">
-    <a class="location-card" href="#malaga">
+    <a class="location-card" href="malaga.html">
       <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80');"></div>
       <div class="card-content">
         <h2>Malaga</h2>
         <span>See latest weather</span>
       </div>
     </a>
-    <a class="location-card" href="#tenerife">
+    <a class="location-card" href="tenerife.html">
       <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1464983953574-0892a716854b?auto=format&fit=crop&w=800&q=80');"></div>
       <div class="card-content">
         <h2>Tenerife</h2>
         <span>See latest weather</span>
       </div>
     </a>
-    <a class="location-card" href="#crete">
+    <a class="location-card" href="crete.html">
       <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=800&q=80');"></div>
       <div class="card-content">
         <h2>Crete</h2>
         <span>See latest weather</span>
       </div>
     </a>
-    <a class="location-card" href="#dubrovnik">
+    <a class="location-card" href="dubrovnik.html">
       <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1467269204594-9661b134dd2b?auto=format&fit=crop&w=800&q=80');"></div>
       <div class="card-content">
         <h2>Dubrovnik</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="bali.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Bali</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="cancun.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1504609813442-a8924e83f76e?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Cancun</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="majorca.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1554200876-28d1cdfacc68?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Majorca</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="ibiza.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1505728959-c8f323928353?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Ibiza</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="lanzarote.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1533900298311-506ad96812ac?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Lanzarote</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="grancanaria.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1601801388668-0e6f52b05971?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Gran Canaria</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="fuerteventura.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1560369718-ed280608de1e?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Fuerteventura</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="algarve.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1484723091739-30a097e8f929?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Algarve</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="barcelona.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Barcelona</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="paris.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1502602898657-3e91760cbb34?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Paris</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="newyork.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1504615755583-2916b52192e4?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>New York</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="rome.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Rome</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="antalya.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1588920530457-9b3e8b9001cf?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Antalya</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="bodrum.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1532787386201-5c6cddaac82d?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Bodrum</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="mykonos.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1563344223-2cc867587bef?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Mykonos</h2>
+        <span>See latest weather</span>
+      </div>
+    </a>
+    <a class="location-card" href="santorini.html">
+      <div class="card-image" style="background-image: url('https://images.unsplash.com/photo-1509135343344-45cdec7508ce?auto=format&fit=crop&w=800&q=80');"></div>
+      <div class="card-content">
+        <h2>Santorini</h2>
         <span>See latest weather</span>
       </div>
     </a>

--- a/lanzarote.html
+++ b/lanzarote.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Lanzarote Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1533900298311-506ad96812ac?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Lanzarote Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Lanzarote updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(29.0469, -13.5899);</script>
+</body>
+</html>
+

--- a/majorca.html
+++ b/majorca.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Majorca Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1554200876-28d1cdfacc68?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Majorca Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Majorca updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(39.6953, 3.0176);</script>
+</body>
+</html>
+

--- a/malaga.html
+++ b/malaga.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Malaga Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Malaga Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Malaga updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(36.7202, -4.4203);</script>
+</body>
+</html>

--- a/mykonos.html
+++ b/mykonos.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Mykonos Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1563344223-2cc867587bef?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Mykonos Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Mykonos updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(37.4467, 25.3289);</script>
+</body>
+</html>
+

--- a/newyork.html
+++ b/newyork.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>New York Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1504615755583-2916b52192e4?auto=format&fit=crop&w=1050&q=80');">
+    <h1>New York Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for New York updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(40.7128, -74.0060);</script>
+</body>
+</html>
+

--- a/paris.html
+++ b/paris.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Paris Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1502602898657-3e91760cbb34?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Paris Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Paris updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(48.8566, 2.3522);</script>
+</body>
+</html>
+

--- a/rome.html
+++ b/rome.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Rome Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Rome Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Rome updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(41.9028, 12.4964);</script>
+</body>
+</html>
+

--- a/santorini.html
+++ b/santorini.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Santorini Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1509135343344-45cdec7508ce?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Santorini Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Santorini updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(36.3932, 25.4615);</script>
+</body>
+</html>
+

--- a/tenerife.html
+++ b/tenerife.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tenerife Weather</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { margin:0; font-family:'Inter',sans-serif; background:#101116; color:white; text-align:center; }
+    .hero { height:260px; background-size:cover; background-position:center; display:flex; align-items:center; justify-content:center; }
+    .hero h1 { background:#0009; padding:16px 24px; border-radius:8px; }
+    .forecast-cards { display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin:20px auto; }
+    .day-card { background:#1b1c22; border:1px solid #333; border-radius:8px; padding:12px; width:120px; }
+    .day-card .icon { font-size:32px; margin-bottom:4px; }
+    .signup-section { margin:40px auto; max-width:400px; }
+    .signup-form { display:flex; gap:8px; flex-direction:column; }
+    .signup-form input[type=email] { padding:8px 12px; border-radius:4px; border:1px solid #555; flex:1; }
+    .signup-form button { padding:8px 20px; border:none; border-radius:4px; background:#0ea5e9; color:#fff; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div class="hero" style="background-image:url('https://images.unsplash.com/photo-1464983953574-0892a716854b?auto=format&fit=crop&w=1050&q=80');">
+    <h1>Tenerife Weather</h1>
+  </div>
+  <div id="forecast">Loading forecast...</div>
+  <section class="signup-section">
+    <h3>Sign up for Tenerife updates</h3>
+    <form class="signup-form" onsubmit="event.preventDefault();alert('Thanks for signing up!');">
+      <input type="email" placeholder="Enter your email" required>
+      <button type="submit">Sign Up</button>
+    </form>
+  </section>
+  <script src="weather.js"></script>
+  <script>loadWeather(28.2916, -16.6291);</script>
+</body>
+</html>

--- a/weather.js
+++ b/weather.js
@@ -1,0 +1,38 @@
+async function loadWeather(lat, lon) {
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&daily=weathercode,temperature_2m_max,temperature_2m_min&timezone=auto`;
+  try {
+    const res = await fetch(url);
+    const data = await res.json();
+    renderForecast(data.daily);
+  } catch (err) {
+    document.getElementById('forecast').textContent = 'Failed to load weather.';
+  }
+}
+
+function getIcon(code) {
+  if (code === 0) return '☀️';
+  if (code === 1 || code === 2) return '⛅';
+  return '☁️';
+}
+
+function renderForecast(daily) {
+  const container = document.getElementById('forecast');
+  const wrapper = document.createElement('div');
+  wrapper.className = 'forecast-cards';
+  for (let i = 0; i < daily.time.length; i++) {
+    const date = new Date(daily.time[i]);
+    const day = date.toLocaleDateString(undefined, {
+      weekday: 'short', month: 'short', day: 'numeric'
+    });
+    const card = document.createElement('div');
+    card.className = 'day-card';
+    card.innerHTML = `
+      <div class="icon">${getIcon(daily.weathercode[i])}</div>
+      <div class="day">${day}</div>
+      <div class="temp">${daily.temperature_2m_min[i]}° / ${daily.temperature_2m_max[i]}°</div>
+    `;
+    wrapper.appendChild(card);
+  }
+  container.innerHTML = '';
+  container.appendChild(wrapper);
+}


### PR DESCRIPTION
## Summary
- upgrade weather forecast UI with icons and day labels
- add colourful hero imagery and signup forms to each destination page
- expand homepage grid to 20 popular destinations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6855390ed0a08332bcb28be711f75481